### PR TITLE
Adding key bindings for copy-mode-vi as well

### DIFF
--- a/scripts/tmux_click_copy.sh
+++ b/scripts/tmux_click_copy.sh
@@ -32,4 +32,4 @@ same_rect="#{&&:${same_start},${same_end}}"
 same_selection="#{&&:${same_rect},#{selection_present}}" # check if text is still being selected
 
 # run the expression in tmux
-tmux if -bF "${same_selection}" "send -X -t ${pane_id} copy-pipe-and-cancel"
+tmux if -bF "${same_selection}" "send -X -t ${pane_id} copy-pipe-no-clear"

--- a/tmux-click-copy.tmux
+++ b/tmux-click-copy.tmux
@@ -36,6 +36,12 @@ tmux bind-key -T copy-mode DoubleClick1Pane \
     send-keys -X copy-selection-no-clear \\\; \
     run-shell -b "${TCC_COMMAND}"
 
+tmux bind-key -T copy-mode-vi DoubleClick1Pane \
+    select-pane \\\; \
+    send-keys -X select-word \\\; \
+    send-keys -X copy-selection-no-clear \\\; \
+    run-shell -b "${TCC_COMMAND}"
+
 tmux bind-key -T root DoubleClick1Pane \
     select-pane -t = \\\; \
     if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
@@ -48,6 +54,12 @@ tmux bind-key -T root DoubleClick1Pane \
 
 # Triple LMB Select & Copy (Line)
 tmux bind-key -T copy-mode TripleClick1Pane \
+    select-pane \\\; \
+    send-keys -X select-line \\\; \
+    send-keys -X copy-selection-no-clear \\\; \
+    run-shell -b "${TCC_COMMAND_TRIPLE}"
+
+tmux bind-key -T copy-mode-vi TripleClick1Pane \
     select-pane \\\; \
     send-keys -X select-line \\\; \
     send-keys -X copy-selection-no-clear \\\; \


### PR DESCRIPTION
Related issue: https://github.com/aless3/tmux-click-copy/issues/1

Added keybindings for copy-mode-vi as well.
